### PR TITLE
Reverting SQLAlchemy tuple by introducing finction `clear_record`

### DIFF
--- a/alphanum_code/core.py
+++ b/alphanum_code/core.py
@@ -84,6 +84,10 @@ class AlphaNumCodeManager(object):
         query = self.session.query(AlphaNumCode).order_by(AlphaNumCode.id.desc()).first()
         return query
 
+    def clear_record(self):
+        query = self.session.query(AlphaNumCode).order_by(AlphaNumCode.id.desc()).first()
+        self.session.delete(query)
+
     def next_code(self, info=None):
         """Returns new code based on last registered code in db.
 

--- a/tests/test_alphanum_code.py
+++ b/tests/test_alphanum_code.py
@@ -26,6 +26,7 @@ def coder():
 def test_init_code(coder):
     code = coder.next_code("init code test")
     assert code == INIT_CODE
+    coder.clear_record()
 
 
 def test_next_code(coder):


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_init_code` by deleting the former-written SQLAlchemy tuple by introducing and calling method `clear_record`

The test can fail in this way if the tuple is not removed:
```
>       assert code == INIT_CODE
E       AssertionError: assert '52ZA0' == '52Z9Z'
E         - 52ZA0
E         + 52Z9Z
